### PR TITLE
画像アップロードバグ対応（店舗別トッピングコール情報IDの定義名不正）

### DIFF
--- a/src/app/store/image_upload.tsx
+++ b/src/app/store/image_upload.tsx
@@ -94,7 +94,7 @@ export default function ImageUpload() {
                     storeToppingCalls.formattedToppingOptions.map(([_, toppingOption]) => toppingOption)
 
                 setToppingOptions(toppingOptions)
-                // console.log("formattedOption：", JSON.stringify(formattedOption, null, 2))
+                // console.log("formattedOption：", JSON.stringify(toppingOptions, null, 2))
             } catch (error) {
                 console.error("トッピングコール情報取得エラー：", error)
                 setError("トッピングコール情報取得時にエラーが発生しました。")
@@ -260,7 +260,7 @@ export default function ImageUpload() {
                 storeToppingCallId
             }
         }))
-        // console.log("toppingId, optionId, storeToppingCallId：", toppingId, optionId, storeToppingCallId)
+        console.log("toppingId, optionId, storeToppingCallId：", toppingId, optionId, storeToppingCallId)
     }
 
     if (loading || dataLoading) {

--- a/src/components/store/ImageUploadToppingSelector.tsx
+++ b/src/components/store/ImageUploadToppingSelector.tsx
@@ -34,7 +34,7 @@ const ImageUploadToppingSelector: React.FC<ImageUploadToppingSelectorProps> = ({
                             onOptionChange(
                                 String(toppingOption.toppingId),
                                 value,
-                                selectedOption?.store_topping_call_id?.toString()
+                                String(selectedOption?.storeToppingCallId)
                             )
                         }}
                         value={selectedOptions[toppingOption.toppingId]

--- a/src/types/storeApiResponse.ts
+++ b/src/types/storeApiResponse.ts
@@ -127,7 +127,7 @@ export interface SimulationToppingOption {
     options: {
         optionId: string | number;
         optionName: string;
-        store_topping_call_id?: string | number;
+        storeToppingCallId?: string | number;
     }[]
 }
 


### PR DESCRIPTION
バグ対応の動作確認完了のためプルリク出します。