### PR TITLE
セキュリティ脆弱性対応

### DIFF
--- a/app.json
+++ b/app.json
@@ -28,10 +28,7 @@
         "backgroundColor": "#ffffff"
       },
       "package": "com.syumeikyo.jNavi",
-      "permissions": [
-        "ACCESS_FINE_LOCATION",
-        "ACCESS_COARSE_LOCATION"
-      ]
+      "permissions": ["ACCESS_FINE_LOCATION", "ACCESS_COARSE_LOCATION"]
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@react-native-firebase/app": "^22.4.0",
         "@react-native-firebase/auth": "^22.4.0",
         "@react-native-google-signin/google-signin": "^13.2.0",
-        "axios": "^1.8.3",
+        "axios": "^1.12.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dotenv": "^16.4.7",
@@ -5872,13 +5872,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.0.tgz",
+      "integrity": "sha512-zt40Pz4zcRXra9CVV31KeyofwiNvAbJ5B6YPz9pMJ+yOSLikvPT4Yi5LjfgjRa9CawVYBaD1JQzIVcIvBejKeA==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -8732,9 +8732,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@react-native-firebase/app": "^22.4.0",
     "@react-native-firebase/auth": "^22.4.0",
     "@react-native-google-signin/google-signin": "^13.2.0",
-    "axios": "^1.8.3",
+    "axios": "^1.12.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dotenv": "^16.4.7",

--- a/src/components/navigation/BottomAppBar.tsx
+++ b/src/components/navigation/BottomAppBar.tsx
@@ -39,7 +39,7 @@ export default function BottomAppBar({ showRoutes = [] }: BottomAppBarProps) {
                     <View style={styles.appMenu}>
                         <Appbar.Action
                             icon="home"
-                            onPress={() => { router.push('test/paperui_sample') }}
+                            onPress={() => { router.push('test/maptest') }}
                         />
                         <Text style={styles.appText}>home</Text>
                     </View>


### PR DESCRIPTION
タイトルの通りです。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update BottomAppBar home route to `test/maptest` and bump axios to 1.13.0, with a minor Android permissions formatting change.
> 
> - **UI/Navigation**:
>   - Update `src/components/navigation/BottomAppBar.tsx` home action to navigate to `test/maptest` (was `test/paperui_sample`).
> - **Dependencies**:
>   - Bump `axios` to `1.13.0` in `package-lock.json`.
> - **Config**:
>   - Reformat Android `permissions` array in `app.json` (no permission changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a05c95353a50d48d13231a44cb1164cdf34eba6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->