### PR TITLE
splash が SDK 56 で小さく表示される問題を修正

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -91,13 +91,29 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         // SDK56 で app.json トップレベルの `splash` プロパティが config schema
         // から廃止された(expo-doctor の schema チェックが additional property
         // 'splash' で fail)。splash は expo-splash-screen の config plugin 経由で
-        // 設定する方式に移行。従来の app.json の splash 設定を忠実に移植している。
+        // 設定する方式に移行。
+        //
+        // legacy(SDK55まで)の `resizeMode: "contain"` は**画面全体**を基準に
+        // 効いていたが、plugin 方式では **`imageWidth` の枠**が基準になる。
+        // imageWidth 未指定だと既定の 100pt で描画され、iPhone 16 Pro(画面幅
+        // 393pt)では約1/4に縮小されてしまう(2026-08-05 の実機QAで検出。
+        // 生成された ios/jNavi/SplashScreen.storyboard のロゴ frame が
+        // width=100 height=100 になっていた)。
+        //
+        // また splash-icon.png は 1024x1024 全面にベージュ(#E5C89A、四隅を
+        // 実測)の背景を持つため、backgroundColor が #ffffff のままだと白地に
+        // ベージュの四角が浮いて見える。legacy では画像が画面幅いっぱいに
+        // 広がっていたので、この不一致は表面化していなかった。
+        //
+        // → imageWidth を画面幅相当まで広げ、backgroundColor を画像の地色に
+        //   揃えることで legacy と同等の見た目に戻す。
         [
             "expo-splash-screen",
             {
                 image: "./assets/splash-icon.png",
                 resizeMode: "contain",
-                backgroundColor: "#ffffff"
+                imageWidth: 400,
+                backgroundColor: "#E5C89A"
             }
         ],
         // 音声入力(音声→テキスト)。expo-speech-recognition は config plugin 方式で


### PR DESCRIPTION
## 概要

SDK 56 の実機QAで検出した splash の表示崩れを修正します。`app.config.ts` の2行（`imageWidth` 追加・`backgroundColor` 変更）のみの変更です。

`docs/expo-sdk-upgrade-plan.md` §14 のチェックリストで **「最重点」として事前に予測されていた事象**が実際に発生していたものです。

## 事象

起動時の splash が、白地にベージュの小さな四角が浮いた状態で表示されていました。

## 原因（2つが重なっていた）

### 1. `imageWidth` 未指定

legacy（SDK 55 まで）の app.json トップレベル `splash` では `resizeMode: "contain"` が**画面全体**を基準に効いていました。SDK 56 で移行した `expo-splash-screen` の config plugin では **`imageWidth` の枠**が基準になります。

未指定だと既定の **100pt** で描画され、iPhone 16 Pro（画面幅 393pt）では**約1/4に縮小**されていました。生成物 `ios/jNavi/SplashScreen.storyboard` で確定：

```xml
<rect key="frame" x="0.0" y="0.0" width="393" height="852"/>    <!-- 画面 -->
<rect key="frame" x="146.5" y="376" width="100" height="100"/>  <!-- ロゴ -->
```

### 2. `backgroundColor` と画像地色の不一致

`splash-icon.png` は 1024×1024 の全面にベージュの背景を持ちます。四隅の実測値は `#E2C79C` / `#E9CEA0` / `#E4C795` / `#E4C896` で、平均 **`#E5C89A`**。

`backgroundColor` が `#ffffff` のままだったため、白地にベージュの四角が浮いて見えていました。legacy では画像が画面幅いっぱいに広がっていたため、この不一致は表面化していませんでした。

## 対処

```diff
 [
     "expo-splash-screen",
     {
         image: "./assets/splash-icon.png",
         resizeMode: "contain",
+        imageWidth: 400,
-        backgroundColor: "#ffffff"
+        backgroundColor: "#E5C89A"
     }
 ],
```

判断の経緯が失われないよう、コード側にも経緯コメントを残しています。

## 検証

### iOS（iPhone 16 Pro / iOS 26.5）

| 段階 | 結果 |
|---|---|
| prebuild 後の storyboard | ロゴ frame `100x100` → **`400x400`** |
| `Assets.car` | `SplashScreenLogo` **1200x1200 @3x（=400pt）** / `SplashScreenBackground` **[0.898, 0.784, 0.604]（=#E5C89A）** |
| 実表示 | **ベージュが全面に広がり、ラーメンが画面幅いっぱいに表示** |

### Android（Pixel 9 / API 35）

| 段階 | 結果 |
|---|---|
| prebuild 後の `colors.xml` | `splashscreen_background` `#ffffff` → **`#E5C89A`** |
| 実表示 | **ベージュが全面に広がり、浮いた四角は解消** |

> [!NOTE]
> **Android 12+ は splash アイコンを円形にマスクします。** そのためイラストのスマートフォンの枠が切り落とされ、丼のみが表示されます。`imageWidth` では制御できない OS の仕様です。背景色が画像の地色と一致しているため見苦しくはありませんが、デザインの意図（ラーメンがスマホに収まっている構図）は Android では伝わりません。円形セーフゾーンに収まる Android 専用画像を用意する対応が別途可能です。

> [!IMPORTANT]
> **SDK 更新時は両OSの prebuild が必要です。** 本作業中、`npx expo prebuild --platform ios` と iOS だけを指定したため、Android のネイティブリソースが旧世代（`#ffffff`）のまま残り、一度目の Android ビルドで修正が反映されませんでした。`app.config.ts` の設定自体は両OS共通で正しく効きます。

## 本PRの変更対象外・SDK 56 実機QA結果（両OS）

| 項目 | iOS | Android |
|---|---|---|
| ビルド | ✅ Build Succeeded（0 error） | ✅ BUILD SUCCESSFUL（JDK 17 / target 36） |
| アプリ起動 | ✅ | ✅ |
| **地図（react-native-maps 1.20→1.27）** | ✅ | ✅ Maps API キーの SHA-1 問題は発生せず |
| 店舗データ取得（バックエンドAPI） | ✅ | ✅ |
| **@gorhom/bottom-sheet（マーカータップ）** | ✅ | ✅ |
| **Google ログイン / Firebase Auth** | ✅ | ✅ |
| ライトモード固定 / 位置情報 / edge-to-edge | ✅ | ✅ |
| 致命的エラー・例外 | 0件 | 0件 |

### QA中に判明した別件（本PRでは未対応）

- **古いAPKでの `Cannot find native module 'ExpoSpeechRecognition'`** — エミュレータに残っていた 6/14 14:34 ビルドの APK が、`expo-speech-recognition` 追加コミット（`a5027b3`、6/14 16:23）より前のものだったため。フルリビルドで解消。計画ドキュメント §13 の gotcha が再現したもので、コードの不具合ではありません。
- **`@react-native-firebase` の名前空間API非推奨警告** — 次のメジャーで削除予定。`getApp()` のモジュラーAPIへの移行が必要（https://rnfirebase.io/migrating-to-v22）。SDK移行とは独立した技術的負債です。

## 未確認（タップ操作を要するもの）

- `expo-speech-recognition`（音声入力）— register タブ → 店舗登録画面。マイク権限ダイアログ含む
- `react-native-element-dropdown` — simulation タブ（券売機）
- `expo-image-picker` — 画像アップロード画面

edge-to-edge は Pixel 9（API 35・ジェスチャーナビ・縦向き）でのみ確認。3ボタンナビ・横向きは未確認です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)