### PR TITLE
API側バリデーション強化に伴うフロント対応

### DIFF
--- a/src/api/Apiclient.ts
+++ b/src/api/Apiclient.ts
@@ -1,6 +1,44 @@
 import axios, { AxiosError, AxiosInstance } from "axios"
 import Constants from "expo-constants"
 import { Platform } from "react-native"
+import { firebaseAuth } from "../config/firebase"
+import { ApiErrorDetail, ApiErrorResponse } from "../types/api"
+
+/**
+ * API から返されたエラーを、ステータスコードとフィールド単位の詳細を保ったまま伝えるError
+ *
+ * 素の Error ではステータスコードも details も失われ、
+ * 「400 はリトライ対象外」「details[].path でインラインエラーを出す」といった
+ * 呼び出し元の判断ができなくなるため、専用の型で保持する。
+ */
+export class ApiError extends Error {
+    /** HTTP ステータスコード（レスポンスを受け取れなかった場合は undefined） */
+    readonly status?: number
+    /** バリデーションエラー時のフィールド単位の詳細 */
+    readonly details?: ApiErrorDetail[]
+
+    constructor(message: string, status?: number, details?: ApiErrorDetail[]) {
+        super(message)
+        this.name = "ApiError"
+        this.status = status
+        this.details = details
+        Object.setPrototypeOf(this, ApiError.prototype)
+    }
+
+    /** フィールド単位のエラー詳細を持つか（＝フォームにインライン表示できるか） */
+    get hasFieldErrors(): boolean {
+        return !!this.details?.length
+    }
+
+    /**
+     * そのまま画面に出せるメッセージ
+     * details があればフィールド単位のメッセージを、無ければ本文を返す
+     */
+    get displayMessage(): string {
+        if (!this.details?.length) return this.message
+        return this.details.map((detail) => detail.msg).join("\n")
+    }
+}
 
 /**
  * APIクライアントの設定を行うクラス
@@ -26,7 +64,7 @@ class ApiClient {
         return apiUrl || 'http://localhost:3000'
     }
 
-    /* 
+    /*
    * APIクライアントのシングルトンインスタンスを取得
    */
     public static getInstance(): AxiosInstance {
@@ -37,29 +75,60 @@ class ApiClient {
                     "Content-Type": "application/json"
                 }
             })
+
+            // 店舗の登録・更新・閉店・画像アップロードは API 側で authenticateUser が
+            // 必須のため、全リクエストに Firebase の ID トークンを付与する。
+            // getIdToken() は有効期限内ならキャッシュを返すので毎回の通信は発生しない。
+            // 未ログイン時はヘッダを付けず、認証不要な参照系APIはそのまま通す。
+            ApiClient.instance.interceptors.request.use(async (config) => {
+                try {
+                    const idToken = await firebaseAuth.currentUser?.getIdToken()
+                    if (idToken) {
+                        config.headers.set("Authorization", `Bearer ${idToken}`)
+                    }
+                } catch (error) {
+                    // トークン更新の失敗でリクエスト自体を止めない。
+                    // 認証不要な参照系APIは通し、認証必須のAPIはサーバが
+                    // 401 と理由付きのメッセージを返す。
+                    console.warn("認証トークンの取得に失敗しました：", error)
+                }
+                return config
+            })
         }
         return ApiClient.instance
     }
 
     /**
    * エラーハンドラー
+   *
+   * API のエラー本文はメッセージのキーが出所ごとに `error` / `message` と異なる
+   * （types/api.ts の ApiErrorResponse を参照）。両方を見て取り出し、
+   * ステータスコードと details を保持した ApiError に詰め替える。
    */
     public static handleError(
         error: unknown,
         defaultMessage: string = "予期せぬエラーが発生しました。"
-    ): Error {
+    ): ApiError {
         if (axios.isAxiosError(error)) {
-            const axiosError = error as AxiosError<{ message?: string }>
-            return new Error(
-                `API呼び出し中にエラーが発生： ${axiosError.response?.data?.message || axiosError.message}`
-            )
+            const axiosError = error as AxiosError<ApiErrorResponse>
+            const data = axiosError.response?.data
+
+            // レスポンス本文が無い（通信断・タイムアウト等）場合は、
+            // axios の英語メッセージではなく呼び出し元が用意した文言を表示する
+            const message = data?.error || data?.message || defaultMessage
+
+            return new ApiError(message, axiosError.response?.status, data?.details)
         }
 
-        if (error instanceof Error) {
+        if (error instanceof ApiError) {
             return error
         }
 
-        return new Error(defaultMessage)
+        if (error instanceof Error) {
+            return new ApiError(error.message)
+        }
+
+        return new ApiError(defaultMessage)
     }
 }
 

--- a/src/app/store/create.tsx
+++ b/src/app/store/create.tsx
@@ -2,7 +2,7 @@ import {
     View, ScrollView, Platform, KeyboardAvoidingView, StyleSheet
 } from "react-native"
 import {
-    Text, TextInput, Button, useTheme, Switch, Snackbar,
+    Text, Button, useTheme, Switch, Snackbar,
     List
 } from "react-native-paper"
 import { useForm, Controller } from "react-hook-form"
@@ -21,6 +21,10 @@ import { generateToppingCalls } from "@/src/utils/toppingFormatter"
 import StoreRegisterToppingOptionSelector from "@/src/components/store/StoreRegisterToppingOptionSelector"
 import { getToppingCallOptions } from "@/src/api/toppingApi"
 import VoiceTextInput from "@/src/components/inputs/VoiceTextInput"
+import FormTextInput from "@/src/components/inputs/FormTextInput"
+import { STORE_TEXT_MAX_LENGTH } from "@/src/constants/validation"
+import { applyApiFieldErrors } from "@/src/utils/apiErrorUtils"
+import { STORE_TEXT_FIELD_NAMES, trimStoreTextFields } from "@/src/utils/storeFormUtils"
 
 /**
  * 店舗情報登録画面コンポーネント
@@ -31,7 +35,7 @@ import VoiceTextInput from "@/src/components/inputs/VoiceTextInput"
  */
 export default function StoreCreate() {
     // フォームの状態管理 (React Hook Form)
-    const { control, handleSubmit, formState: { isSubmitting } } = useForm<StoreData>({
+    const { control, handleSubmit, setError, formState: { isSubmitting } } = useForm<StoreData>({
         defaultValues: {
             // デフォルト値を設定
             store_name: "",
@@ -108,9 +112,9 @@ export default function StoreCreate() {
                 selectedPostCallOptions
             )
 
-            // 送信データを作成
+            // 送信データを作成（保存値と揃えるためテキスト項目はtrim済みで送る）
             const submitData = {
-                ...data,
+                ...trimStoreTextFields(data),
                 topping_calls: toppingCalls
             }
 
@@ -131,7 +135,15 @@ export default function StoreCreate() {
             }, 3000)
         } catch (error) {
             // エラー処理
-            setSnackbarMessage(error instanceof Error ? error.message : "店舗情報登録処理でエラーが発生しました")
+            // 400のdetailsは各入力欄のインラインエラーへ回し、
+            // 入力欄を持たない項目の分だけスナックバーに出す
+            console.error("店舗情報登録エラー：", error)
+            setSnackbarMessage(applyApiFieldErrors(
+                error,
+                setError,
+                STORE_TEXT_FIELD_NAMES,
+                "店舗情報登録処理でエラーが発生しました"
+            ))
             setSnackbarError(true)
             setSnackbarVisible(true)
         }
@@ -216,103 +228,35 @@ export default function StoreCreate() {
                         name='store_name'
                         label="店舗名"
                         isRequired={true}
+                        maxLength={STORE_TEXT_MAX_LENGTH.STORE_NAME}
                     />
 
-                    <Controller
+                    <FormTextInput
                         control={control}
                         name="branch_name"
-                        render={({ field }) => (
-                            <TextInput
-                                mode="outlined"
-                                label="支店名"
-                                value={field.value}
-                                onChangeText={field.onChange}
-                            />
-                        )}
+                        label="支店名"
+                        maxLength={STORE_TEXT_MAX_LENGTH.BRANCH_NAME}
                     />
-                    <Controller
+                    <FormTextInput
                         control={control}
                         name="address"
-                        rules={{
-                            required: "住所は必須項目です"
-                        }}
-                        render={({ field, fieldState: { error } }) => (
-                            <>
-                                <TextInput
-                                    mode="outlined"
-                                    label={
-                                        <Text>
-                                            住所 <Text style={{ color: theme.colors.error }}>*</Text>
-                                        </Text>
-                                    }
-                                    value={field.value}
-                                    onChangeText={field.onChange}
-                                    onBlur={field.onBlur}
-                                    error={!!error}
-                                />
-                                {error && (
-                                    <Text style={{ color: theme.colors.error, fontSize: 10 }}>
-                                        {error.message}
-                                    </Text>
-                                )}
-                            </>
-                        )}
+                        label="住所"
+                        isRequired={true}
+                        maxLength={STORE_TEXT_MAX_LENGTH.ADDRESS}
                     />
-                    <Controller
+                    <FormTextInput
                         control={control}
                         name="business_hours"
-                        rules={{
-                            required: "営業時間は必須項目です"
-                        }}
-                        render={({ field, fieldState: { error } }) => (
-                            <>
-                                <TextInput
-                                    mode="outlined"
-                                    label={
-                                        <Text>
-                                            営業時間 <Text style={{ color: theme.colors.error }}>*</Text>
-                                        </Text>
-                                    }
-                                    value={field.value}
-                                    onChangeText={field.onChange}
-                                    onBlur={field.onBlur}
-                                    error={!!error}
-                                />
-                                {error && (
-                                    <Text style={{ color: theme.colors.error, fontSize: 10 }}>
-                                        {error.message}
-                                    </Text>
-                                )}
-                            </>
-                        )}
+                        label="営業時間"
+                        isRequired={true}
+                        maxLength={STORE_TEXT_MAX_LENGTH.BUSINESS_HOURS}
                     />
-                    <Controller
+                    <FormTextInput
                         control={control}
                         name="regular_holidays"
-                        rules={{
-                            required: "定休日は必須項目です"
-                        }}
-                        render={({ field, fieldState: { error } }) => (
-                            <>
-                                <TextInput
-                                    mode="outlined"
-                                    label={
-                                        <Text>
-                                            定休日 <Text style={{ color: theme.colors.error }}>*</Text>
-                                        </Text>
-                                    }
-                                    value={field.value}
-                                    onChangeText={field.onChange}
-                                    onBlur={field.onBlur}
-                                    error={!!error}
-                                />
-                                {error && (
-                                    <Text style={{ color: theme.colors.error, fontSize: 10 }}>
-                                        {error.message}
-                                    </Text>
-                                )}
-                            </>
-                        )}
+                        label="定休日"
+                        isRequired={true}
+                        maxLength={STORE_TEXT_MAX_LENGTH.REGULAR_HOLIDAYS}
                     />
 
                     {/* 事前食券購入有無ラジオボタン */}
@@ -376,38 +320,22 @@ export default function StoreCreate() {
                     </List.Accordion>
 
                     {/* 詳細情報入力フィールド群 */}
-                    <Controller
+                    <FormTextInput
                         control={control}
                         name="topping_details"
-                        render={({ field }) => (
-                            <TextInput
-                                mode="outlined"
-                                label="トッピング詳細"
-                                value={field.value}
-                                onChangeText={field.onChange}
-                                multiline={true}
-                                numberOfLines={4}
-                                style={{
-                                    minHeight: 120
-                                }}
-                            />
-                        )}
+                        label="トッピング詳細"
+                        maxLength={STORE_TEXT_MAX_LENGTH.TOPPING_DETAILS}
+                        multiline={true}
+                        numberOfLines={4}
                     />
 
-                    <Controller
+                    <FormTextInput
                         control={control}
                         name="call_details"
-                        render={({ field }) => (
-                            <TextInput
-                                mode="outlined"
-                                label="コール詳細"
-                                value={field.value}
-                                onChangeText={field.onChange}
-                                multiline={true}
-                                numberOfLines={4}
-                                style={{ minHeight: 120 }}
-                            />
-                        )}
+                        label="コール詳細"
+                        maxLength={STORE_TEXT_MAX_LENGTH.CALL_DETAILS}
+                        multiline={true}
+                        numberOfLines={4}
                     />
 
                     {/* 全体増量の有無ラジオ選択 */}
@@ -441,20 +369,13 @@ export default function StoreCreate() {
                             )}
                         />
                     </View>
-                    <Controller
+                    <FormTextInput
                         control={control}
                         name="lot_detail"
-                        render={({ field }) => (
-                            <TextInput
-                                mode="outlined"
-                                label="ロット詳細"
-                                value={field.value}
-                                onChangeText={field.onChange}
-                                multiline={true}
-                                numberOfLines={4}
-                                style={{ minHeight: 120 }}
-                            />
-                        )}
+                        label="ロット詳細"
+                        maxLength={STORE_TEXT_MAX_LENGTH.LOT_DETAIL}
+                        multiline={true}
+                        numberOfLines={4}
                     />
                     {/* 登録ボタン */}
                     <Button

--- a/src/app/store/detail.tsx
+++ b/src/app/store/detail.tsx
@@ -11,6 +11,7 @@ import LoadingErrorContainer from '@/src/components/feedback/LoadingErrorContain
 import HeaderAppBar from '@/src/components/navigation/HeaderAppBar'
 import { FormattedToppingOptionNames } from '@/src/types/topping'
 import ToppingOptionsAccordion from '@/src/components/store/ToppingOptionsAccordion'
+import { toDisplayMessage } from '@/src/utils/apiErrorUtils'
 
 
 /**
@@ -67,7 +68,7 @@ export default function StoreDetails() {
 
             } catch (err) {
                 console.error("店舗情報取得処理エラー：", err)
-                setError(err instanceof Error ? err.message : "店舗情報取得でエラーが発生しました。")
+                setError(toDisplayMessage(err, "店舗情報取得でエラーが発生しました。"))
                 setSnackBarVisible(true)
             } finally {
                 setLoading(false)
@@ -112,7 +113,7 @@ export default function StoreDetails() {
                             }, 3000)
                         } catch (error) {
                             console.error("閉店処理エラー：", error)
-                            setError(error instanceof Error ? error.message : "閉店処理でエラーが発生しました。")
+                            setError(toDisplayMessage(error, "閉店処理でエラーが発生しました。"))
                             setSnackBarVisible(true)
                         }
                     }

--- a/src/app/store/image_upload.tsx
+++ b/src/app/store/image_upload.tsx
@@ -1,5 +1,5 @@
 import { router, useLocalSearchParams } from "expo-router"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { Button, Divider, RadioButton, Snackbar, Text, TextInput, useTheme } from "react-native-paper"
 import * as ImagePicker from "expo-image-picker"
 import { SaveFormat, ImageManipulator } from "expo-image-manipulator"
@@ -15,12 +15,23 @@ import { SelectedToppingInfo, StoreImageUploadData } from "@/src/types/storeImag
 import { uploadStoreImage } from "@/src/api/ImageApi"
 import ImageUploadToppingSelector from "@/src/components/store/ImageUploadToppingSelector"
 import { SimulationToppingOption } from "@/src/types/storeApiResponse"
+import { toDisplayMessage } from "@/src/utils/apiErrorUtils"
 
 // メニュータイプの定義
 const MENU_TYPES = [
     { label: '通常メニュー', value: '1' },
     { label: '限定メニュー', value: '2' }
 ]
+
+// 保存フォーマットに対応する MIME タイプ
+// data URL のプレフィックスは「元画像の MIME」ではなく「実際に保存した形式」から
+// 引くこと。両者がズレると HEIC 等でサーバの形式チェック（jpeg|png|gif|webp）に
+// 弾かれて 400 になり、gif の場合は中身が JPEG のまま gif として登録される。
+const MIME_TYPE_BY_FORMAT: Record<SaveFormat, string> = {
+    [SaveFormat.JPEG]: 'image/jpeg',
+    [SaveFormat.PNG]: 'image/png',
+    [SaveFormat.WEBP]: 'image/webp'
+}
 
 export default function ImageUpload() {
     const { id } = useLocalSearchParams<{ id: string }>()
@@ -34,7 +45,6 @@ export default function ImageUpload() {
     const [loading, setLoading] = useState<boolean>(true)
     const [uploading, setUploading] = useState<boolean>(false)
     const [dataLoading, setDataLoading] = useState<boolean>(true)
-    const [error, setError] = useState<string | null>(null)
     const [snackBarVisible, setSnackBarVisible] = useState<boolean>(false)
     const [snackBarMessage, setSnackBarMessage] = useState<string>('')
     const [isSuccess, setIsSuccess] = useState<boolean>(false)
@@ -45,6 +55,22 @@ export default function ImageUpload() {
 
     const [selectedToppingInfo, setSelectedToppingInfo] = useState<Record<string, SelectedToppingInfo>>({})
 
+    /**
+     * スナックバーへメッセージを表示する
+     *
+     * 表示文言と成否を必ずセットで更新する。片方だけ更新すると、
+     * 成功扱いのまま本文が空になる／エラー色のまま前回の文言が残る、といった
+     * 表示崩れが起きるため、この関数以外から個別に更新しないこと。
+     *
+     * @param message 表示するメッセージ
+     * @param success 成功メッセージとして表示するか
+     */
+    const showSnackBar = useCallback((message: string, success: boolean = false) => {
+        setSnackBarMessage(message)
+        setIsSuccess(success)
+        setSnackBarVisible(true)
+    }, [])
+
     // 画像ピッカーの権限確認
     useEffect(() => {
         (async () => {
@@ -52,19 +78,17 @@ export default function ImageUpload() {
 
             if (galleryStatus.status === 'denied' ||
                 (galleryStatus.accessPrivileges === 'none')) {
-                setError("本画面では画像へのアクセス許可が必要です。")
-                setSnackBarVisible(true)
+                showSnackBar("本画面では画像へのアクセス許可が必要です。")
             }
 
             // 制限付きアクセスの場合（必要に応じて）
             if (galleryStatus.accessPrivileges === 'limited') {
-                setSnackBarMessage("一部の写真のみへのアクセスが許可されています")
-                setSnackBarVisible(true)
+                showSnackBar("一部の写真のみへのアクセスが許可されています")
             }
 
             setLoading(false)
         })()
-    }, [])
+    }, [showSnackBar])
 
     // トッピング情報の取得
     useEffect(() => {
@@ -97,15 +121,14 @@ export default function ImageUpload() {
                 // console.log("formattedOption：", JSON.stringify(toppingOptions, null, 2))
             } catch (error) {
                 console.error("トッピングコール情報取得エラー：", error)
-                setError("トッピングコール情報取得時にエラーが発生しました。")
-                setSnackBarVisible(true)
+                showSnackBar(toDisplayMessage(error, "トッピングコール情報取得時にエラーが発生しました。"))
             } finally {
                 setDataLoading(false)
             }
         }
         fetchToppingData()
 
-    }, [id])
+    }, [id, showSnackBar])
 
     /**
      * 画像選択ダイアログを表示し、選択された画像をprocessImageに渡す
@@ -126,8 +149,7 @@ export default function ImageUpload() {
             }
         } catch (error) {
             console.error("画像選択時にエラーが発生：", error)
-            setError("画像選択時にエラーが発生しました。")
-            setSnackBarVisible(true)
+            showSnackBar("画像選択時にエラーが発生しました。")
         }
     }
 
@@ -161,7 +183,10 @@ export default function ImageUpload() {
                 base64: true
             })
 
-            const formattedBase64 = `data:${mimeType};base64,${result.base64}`
+            // プレフィックスは保存に使った format から引く。元の mimeType を使うと
+            // HEIC 等がそのまま入って 400 になる（getFormatFromMimeType が JPEG へ
+            // フォールバックしても、宣言だけ HEIC のままになるため）
+            const formattedBase64 = `data:${MIME_TYPE_BY_FORMAT[format]};base64,${result.base64}`
             // console.log("画像サイズ圧縮後：", formattedBase64)
 
             // 処理後の画像をステートに保存
@@ -169,13 +194,16 @@ export default function ImageUpload() {
             setImageBase64(formattedBase64 || null)
         } catch (error) {
             console.error("画像サイズ圧縮中にエラーが発生:", error)
-            setError("画像サイズ圧縮処理に失敗しました。")
-            setSnackBarVisible(true)
+            showSnackBar("画像サイズ圧縮処理に失敗しました。")
         }
     }
 
     /**
      * MIMEタイプをチェックしてBase64形式で画像を決める
+     *
+     * サーバが受け付けない形式（HEIC/HEIF・BMP 等）や mimeType 不明の場合は
+     * JPEG へ再エンコードして必ず許可形式に正規化する。
+     *
      * @param mimeType MIMEタイプ
      * @returns Base64形式で画像を保存する形式
      */
@@ -227,9 +255,7 @@ export default function ImageUpload() {
             await uploadStoreImage(id, uploadData)
 
             // 完了表示
-            setIsSuccess(true)
-            setSnackBarMessage("画像アップロード処理が完了しました。")
-            setSnackBarVisible(true)
+            showSnackBar("画像アップロード処理が完了しました。", true)
 
             // スナックバー表示後にMAPに遷移する。
             setTimeout(() => {
@@ -240,8 +266,9 @@ export default function ImageUpload() {
 
         } catch (error) {
             console.error('アップロードエラー:', error)
-            setError(error instanceof Error ? error.message : '画像のアップロードに失敗しました')
-            setSnackBarVisible(true)
+            // 画像形式エラーは 400 で「無効な画像データ形式です」等が返るため、
+            // サーバのメッセージをそのまま出す（details があればそちらを優先）
+            showSnackBar(toDisplayMessage(error, '画像のアップロードに失敗しました'))
         } finally {
             setUploading(false)
         }
@@ -395,7 +422,7 @@ export default function ImageUpload() {
                     backgroundColor: isSuccess ? theme.colors.primary : theme.colors.error
                 }}
             >
-                {isSuccess ? snackBarMessage : error}
+                {snackBarMessage}
             </Snackbar>
         </SafeAreaView>
     )

--- a/src/app/store/update.tsx
+++ b/src/app/store/update.tsx
@@ -2,7 +2,7 @@ import {
     View, ScrollView, Platform, KeyboardAvoidingView, StyleSheet
 } from "react-native"
 import {
-    Text, TextInput, Button, useTheme, Switch, Snackbar,
+    Text, Button, useTheme, Switch, Snackbar,
     List
 } from "react-native-paper"
 import { useForm, Controller } from "react-hook-form"
@@ -20,6 +20,10 @@ import { FontAwesome6 } from "@expo/vector-icons"
 import { generateToppingCalls } from "@/src/utils/toppingFormatter"
 import StoreRegisterToppingOptionSelector from "@/src/components/store/StoreRegisterToppingOptionSelector"
 import { getToppingCallOptions } from "@/src/api/toppingApi"
+import FormTextInput from "@/src/components/inputs/FormTextInput"
+import { STORE_TEXT_MAX_LENGTH } from "@/src/constants/validation"
+import { applyApiFieldErrors } from "@/src/utils/apiErrorUtils"
+import { STORE_TEXT_FIELD_NAMES, trimStoreTextFields } from "@/src/utils/storeFormUtils"
 
 /**
  * 店舗情報更新画面コンポーネント
@@ -30,7 +34,7 @@ import { getToppingCallOptions } from "@/src/api/toppingApi"
  */
 export default function StoreUpdate() {
     // フォームの状態管理 (React Hook Form)
-    const { control, handleSubmit, formState: { isSubmitting }, reset } = useForm<StoreData>({
+    const { control, handleSubmit, setError, formState: { isSubmitting }, reset } = useForm<StoreData>({
         defaultValues: {
             // デフォルト値を設定
             store_name: "",
@@ -141,9 +145,9 @@ export default function StoreUpdate() {
                 selectedPostCallOptions
             )
 
-            // 送信データを作成
+            // 送信データを作成（保存値と揃えるためテキスト項目はtrim済みで送る）
             const submitData = {
-                ...data,
+                ...trimStoreTextFields(data),
                 topping_calls: toppingCalls
             }
 
@@ -169,7 +173,15 @@ export default function StoreUpdate() {
 
         } catch (error) {
             // エラー処理
-            setSnackbarMessage(error instanceof Error ? error.message : "店舗情報登録処理でエラーが発生しました")
+            // 400のdetailsは各入力欄のインラインエラーへ回し、
+            // 入力欄を持たない項目の分だけスナックバーに出す
+            console.error("店舗情報更新エラー：", error)
+            setSnackbarMessage(applyApiFieldErrors(
+                error,
+                setError,
+                STORE_TEXT_FIELD_NAMES,
+                "店舗情報更新処理でエラーが発生しました"
+            ))
             setSnackbarError(true)
             setSnackbarVisible(true)
         }
@@ -249,129 +261,39 @@ export default function StoreUpdate() {
                 >
                     <StatusBar style={theme.dark ? "light" : "dark"} />
                     {/* 基本情報入力フィールド群 */}
-                    <Controller
+                    <FormTextInput
                         control={control}
                         name="store_name"
-                        rules={{
-                            required: "店舗名は必須項目です"
-                        }}
-                        render={({ field, fieldState: { error } }) => (
-                            <>
-                                <TextInput
-                                    mode="outlined"
-                                    label={
-                                        <Text>
-                                            店舗名 <Text style={{ color: theme.colors.error }}>*</Text>
-                                        </Text>
-                                    }
-                                    value={field.value}
-                                    onChangeText={field.onChange}
-                                    onBlur={field.onBlur}
-                                    error={!!error}
-                                />
-                                {error && (
-                                    <Text style={{ color: theme.colors.error, fontSize: 10 }}>
-                                        {error.message}
-                                    </Text>
-                                )}
-                            </>
-                        )}
+                        label="店舗名"
+                        isRequired={true}
+                        maxLength={STORE_TEXT_MAX_LENGTH.STORE_NAME}
                     />
-                    <Controller
+                    <FormTextInput
                         control={control}
                         name="branch_name"
-                        render={({ field }) => (
-                            <TextInput
-                                mode="outlined"
-                                label="支店名"
-                                value={field.value}
-                                onChangeText={field.onChange}
-                            />
-                        )}
+                        label="支店名"
+                        maxLength={STORE_TEXT_MAX_LENGTH.BRANCH_NAME}
                     />
-                    <Controller
+                    <FormTextInput
                         control={control}
                         name="address"
-                        rules={{
-                            required: "住所は必須項目です"
-                        }}
-                        render={({ field, fieldState: { error } }) => (
-                            <>
-                                <TextInput
-                                    mode="outlined"
-                                    label={
-                                        <Text>
-                                            住所 <Text style={{ color: theme.colors.error }}>*</Text>
-                                        </Text>
-                                    }
-                                    value={field.value}
-                                    onChangeText={field.onChange}
-                                    onBlur={field.onBlur}
-                                    error={!!error}
-                                />
-                                {error && (
-                                    <Text style={{ color: theme.colors.error, fontSize: 10 }}>
-                                        {error.message}
-                                    </Text>
-                                )}
-                            </>
-                        )}
+                        label="住所"
+                        isRequired={true}
+                        maxLength={STORE_TEXT_MAX_LENGTH.ADDRESS}
                     />
-                    <Controller
+                    <FormTextInput
                         control={control}
                         name="business_hours"
-                        rules={{
-                            required: "営業時間は必須項目です"
-                        }}
-                        render={({ field, fieldState: { error } }) => (
-                            <>
-                                <TextInput
-                                    mode="outlined"
-                                    label={
-                                        <Text>
-                                            営業時間 <Text style={{ color: theme.colors.error }}>*</Text>
-                                        </Text>
-                                    }
-                                    value={field.value}
-                                    onChangeText={field.onChange}
-                                    onBlur={field.onBlur}
-                                    error={!!error}
-                                />
-                                {error && (
-                                    <Text style={{ color: theme.colors.error, fontSize: 10 }}>
-                                        {error.message}
-                                    </Text>
-                                )}
-                            </>
-                        )}
+                        label="営業時間"
+                        isRequired={true}
+                        maxLength={STORE_TEXT_MAX_LENGTH.BUSINESS_HOURS}
                     />
-                    <Controller
+                    <FormTextInput
                         control={control}
                         name="regular_holidays"
-                        rules={{
-                            required: "定休日は必須項目です"
-                        }}
-                        render={({ field, fieldState: { error } }) => (
-                            <>
-                                <TextInput
-                                    mode="outlined"
-                                    label={
-                                        <Text>
-                                            定休日 <Text style={{ color: theme.colors.error }}>*</Text>
-                                        </Text>
-                                    }
-                                    value={field.value}
-                                    onChangeText={field.onChange}
-                                    onBlur={field.onBlur}
-                                    error={!!error}
-                                />
-                                {error && (
-                                    <Text style={{ color: theme.colors.error, fontSize: 10 }}>
-                                        {error.message}
-                                    </Text>
-                                )}
-                            </>
-                        )}
+                        label="定休日"
+                        isRequired={true}
+                        maxLength={STORE_TEXT_MAX_LENGTH.REGULAR_HOLIDAYS}
                     />
 
                     {/* 事前食券購入有無ラジオボタン */}
@@ -435,38 +357,22 @@ export default function StoreUpdate() {
                     </List.Accordion>
 
                     {/* 詳細情報入力フィールド群 */}
-                    <Controller
+                    <FormTextInput
                         control={control}
                         name="topping_details"
-                        render={({ field }) => (
-                            <TextInput
-                                mode="outlined"
-                                label="トッピング詳細"
-                                value={field.value}
-                                onChangeText={field.onChange}
-                                multiline={true}
-                                numberOfLines={4}
-                                style={{
-                                    minHeight: 120
-                                }}
-                            />
-                        )}
+                        label="トッピング詳細"
+                        maxLength={STORE_TEXT_MAX_LENGTH.TOPPING_DETAILS}
+                        multiline={true}
+                        numberOfLines={4}
                     />
 
-                    <Controller
+                    <FormTextInput
                         control={control}
                         name="call_details"
-                        render={({ field }) => (
-                            <TextInput
-                                mode="outlined"
-                                label="コール詳細"
-                                value={field.value}
-                                onChangeText={field.onChange}
-                                multiline={true}
-                                numberOfLines={4}
-                                style={{ minHeight: 120 }}
-                            />
-                        )}
+                        label="コール詳細"
+                        maxLength={STORE_TEXT_MAX_LENGTH.CALL_DETAILS}
+                        multiline={true}
+                        numberOfLines={4}
                     />
 
                     {/* 全体増量の有無ラジオ選択 */}
@@ -500,20 +406,13 @@ export default function StoreUpdate() {
                             )}
                         />
                     </View>
-                    <Controller
+                    <FormTextInput
                         control={control}
                         name="lot_detail"
-                        render={({ field }) => (
-                            <TextInput
-                                mode="outlined"
-                                label="ロット詳細"
-                                value={field.value}
-                                onChangeText={field.onChange}
-                                multiline={true}
-                                numberOfLines={4}
-                                style={{ minHeight: 120 }}
-                            />
-                        )}
+                        label="ロット詳細"
+                        maxLength={STORE_TEXT_MAX_LENGTH.LOT_DETAIL}
+                        multiline={true}
+                        numberOfLines={4}
                     />
                     {/* 登録ボタン */}
                     <Button

--- a/src/components/inputs/FormTextInput.tsx
+++ b/src/components/inputs/FormTextInput.tsx
@@ -1,0 +1,168 @@
+import { FormTextInputProps } from "@/src/types/form"
+import { Controller, FieldValues, Path, RegisterOptions } from "react-hook-form"
+import { StyleSheet, View } from "react-native"
+import { Text, TextInput, useTheme } from "react-native-paper"
+import VoiceInputButton from "./VoiceInputButton"
+import React from "react"
+import { countChars } from "@/src/utils/textUtils"
+
+/**
+ * 店舗フォーム共通のテキスト入力コンポーネント
+ *
+ * `react-hook-form`の`Controller`をラップし、サーバ側のバリデーションと
+ * 同じ基準で入力を検証する。
+ *
+ * - 必須項目は空白のみ（"   "）も弾く。`required`だけでは truthy な文字列として
+ *   通ってしまい、サーバの `trim()` 後 `notEmpty()` で 400 になるため。
+ * - 文字数は trim 後・コードポイント基準で数える（{@link countChars} 参照）。
+ * - `enableVoiceInput`が真のとき、TextInputの外側(兄弟要素)に音声入力ボタンを
+ *   並べて表示する。通常の手入力は妨げない。
+ *
+ * @param {FormTextInputProps<T>} props - コンポーネントのプロパティ
+ * @param {Control<T>} props.control - `react-hook-form`の`Control`オブジェクト
+ * @param {Path<T>} props.name - フォームのフィールド名
+ * @param {string} props.label - ラベル
+ * @param {boolean} [props.isRequired=false] - 必須項目かどうか
+ * @param {number} [props.maxLength] - 文字数上限（未指定なら上限なし）
+ * @param {boolean} [props.multiline=false] - 複数行入力かどうか
+ * @param {number} [props.numberOfLines=1] - 複数行入力の行数
+ * @param {boolean} [props.enableVoiceInput=false] - 音声入力ボタンを表示するか
+ * @param {(value: string) => void} [props.onSpeechResult] - 音声認識結果を受け取る関数
+ * @returns {React.ReactElement} `react-hook-form`の`Controller`コンポーネント
+ */
+function FormTextInput<T extends FieldValues>({
+    control,
+    name,
+    label,
+    isRequired = false,
+    maxLength,
+    multiline = false,
+    numberOfLines = 1,
+    enableVoiceInput = false,
+    onSpeechResult
+}: FormTextInputProps<T>): React.ReactElement {
+    const theme = useTheme()
+
+    const rules: Omit<
+        RegisterOptions<T, Path<T>>,
+        "valueAsNumber" | "valueAsDate" | "setValueAs" | "disabled"
+    > = {
+        ...(isRequired ? { required: `${label}は必須項目です` } : {}),
+        validate: {
+            ...(isRequired
+                ? {
+                    notBlank: (value: unknown) =>
+                        typeof value !== "string" ||
+                        value.trim().length > 0 ||
+                        `${label}を入力してください`
+                }
+                : {}),
+            ...(maxLength
+                ? {
+                    maxLength: (value: unknown) =>
+                        typeof value !== "string" ||
+                        countChars(value.trim()) <= maxLength ||
+                        `${label}は${maxLength}文字以内で入力してください`
+                }
+                : {})
+        }
+    }
+
+    return (
+        <Controller
+            control={control}
+            name={name}
+            rules={rules}
+            render={({ field, fieldState: { error } }) => {
+                const currentValue = typeof field.value === "string" ? field.value : ""
+                const charCount = countChars(currentValue.trim())
+
+                return (
+                    <View style={styles.inputContainer}>
+                        <View style={styles.inputRow}>
+                            <TextInput
+                                mode='outlined'
+                                label={
+                                    <Text>
+                                        {label} {isRequired && <Text style={{ color: theme.colors.error }}>*</Text>}
+                                    </Text>
+                                }
+                                value={currentValue}
+                                onChangeText={field.onChange}
+                                onBlur={field.onBlur}
+                                error={!!error}
+                                multiline={multiline}
+                                numberOfLines={numberOfLines}
+                                // RNのmaxLengthはUTF-16のコード単位で数えるため、上限をそのまま
+                                // 渡すと絵文字がサーバより早く切られてしまう。サーバ基準の1文字は
+                                // 最大3コード単位（サロゲートペア＋異体字セレクタ）なので、
+                                // 4倍を暴走ペースト対策の上限とし、厳密な判定はvalidateに任せる。
+                                maxLength={maxLength !== undefined ? maxLength * 4 : undefined}
+                                style={[styles.input, multiline ? { minHeight: 120 } : null]}
+                            />
+                            {enableVoiceInput && (
+                                <VoiceInputButton
+                                    fieldName={label}
+                                    size={20}
+                                    onSpeechResult={(text) => {
+                                        // フォームの値を更新
+                                        field.onChange(text)
+                                        // 親コンポーネントに通知(任意)
+                                        onSpeechResult?.(text)
+                                    }}
+                                />
+                            )}
+                        </View>
+                        <View style={styles.helperRow}>
+                            <Text style={[styles.errorText, { color: theme.colors.error }]}>
+                                {error?.message ?? ""}
+                            </Text>
+                            {maxLength !== undefined && (
+                                <Text
+                                    style={[
+                                        styles.counterText,
+                                        {
+                                            color: charCount > maxLength
+                                                ? theme.colors.error
+                                                : theme.colors.onSurfaceVariant
+                                        }
+                                    ]}
+                                >
+                                    {charCount} / {maxLength}
+                                </Text>
+                            )}
+                        </View>
+                    </View>
+                )
+            }}
+        />
+    )
+}
+
+const styles = StyleSheet.create({
+    inputContainer: {
+        marginBottom: 16
+    },
+    inputRow: {
+        flexDirection: 'row',
+        alignItems: 'center'
+    },
+    input: {
+        flex: 1
+    },
+    helperRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'flex-start'
+    },
+    errorText: {
+        flex: 1,
+        fontSize: 10
+    },
+    counterText: {
+        fontSize: 10,
+        marginLeft: 8
+    }
+})
+
+export default FormTextInput

--- a/src/components/inputs/VoiceTextInput.tsx
+++ b/src/components/inputs/VoiceTextInput.tsx
@@ -1,95 +1,21 @@
 import { VoiceTextInputProps } from "@/src/types/voice"
-import { Controller, FieldValues } from "react-hook-form"
-import { StyleSheet, View } from "react-native"
-import { Text, TextInput, useTheme } from "react-native-paper"
-import VoiceInputButton from "./VoiceInputButton"
+import { FieldValues } from "react-hook-form"
 import React from "react"
+import FormTextInput from "./FormTextInput"
 
 /**
  * 音声入力に対応したTextInputコンポーネント。
  *
- * `react-hook-form`の`Controller`コンポーネントをラップし、TextInputの隣に音声入力
- * ボタンを並べて表示します。マイクボタンはTextInputの外側(兄弟要素)に配置している
- * ため、通常の手入力を妨げません。音声認識結果を受け取るとフォームの値を更新し、
- * `onSpeechResult`が指定されていれば親コンポーネントにも通知します。
+ * 検証・文字数カウント・エラー表示は{@link FormTextInput}と共通で、
+ * 本コンポーネントは音声入力ボタンを有効にした薄いラッパー。
  *
  * @param {VoiceTextInputProps<T>} props - コンポーネントのプロパティ
- * @param {Control<T>} props.control - `react-hook-form`の`Controller`コンポーネントに渡す`Control`オブジェクト
- * @param {Path<T>} props.name - フォームのフィールド名
- * @param {string} props.label - ラベル
- * @param {boolean} [props.isRequired=false] - 必須項目かどうか
- * @param {boolean} [props.multiline=false] - 複数行入力かどうか
- * @param {number} [props.numberOfLines=1] - 複数行入力の行数
- * @param {(value: string) => void} [props.onSpeechResult] - 音声認識結果を受け取る関数
- * @returns {React.ReactElement} `react-hook-form`の`Controller`コンポーネント
+ * @returns {React.ReactElement} 音声入力ボタン付きのFormTextInput
  */
-function VoiceTextInput<T extends FieldValues>({
-    control,
-    name,
-    label,
-    isRequired = false,
-    multiline = false,
-    numberOfLines = 1,
-    onSpeechResult
-}: VoiceTextInputProps<T>): React.ReactElement {
-    const theme = useTheme()
-
-    return (
-        <Controller
-            control={control}
-            name={name}
-            rules={isRequired ? { required: `${label}は必須項目です` } : {}}
-            render={({ field, fieldState: { error } }) => (
-                <View style={styles.inputContainer}>
-                    <View style={styles.inputRow}>
-                        <TextInput
-                            mode='outlined'
-                            label={
-                                <Text>
-                                    {label} {isRequired && <Text style={{ color: theme.colors.primary }}>*</Text>}
-                                </Text>
-                            }
-                            value={field.value}
-                            onChangeText={field.onChange}
-                            onBlur={field.onBlur}
-                            error={!!error}
-                            multiline={multiline}
-                            numberOfLines={numberOfLines}
-                            style={[styles.input, multiline ? { minHeight: 120 } : null]}
-                        />
-                        <VoiceInputButton
-                            fieldName={label}
-                            size={20}
-                            onSpeechResult={(text) => {
-                                // フォームの値を更新
-                                field.onChange(text)
-                                // 親コンポーネントに通知(任意)
-                                onSpeechResult?.(text)
-                            }}
-                        />
-                    </View>
-                    {error && (
-                        <Text style={{ color: theme.colors.error, fontSize: 10 }}>
-                            {error.message}
-                        </Text>
-                    )}
-                </View>
-            )}
-        />
-    )
+function VoiceTextInput<T extends FieldValues>(
+    props: VoiceTextInputProps<T>
+): React.ReactElement {
+    return <FormTextInput {...props} enableVoiceInput={true} />
 }
-
-const styles = StyleSheet.create({
-    inputContainer: {
-        marginBottom: 16
-    },
-    inputRow: {
-        flexDirection: 'row',
-        alignItems: 'center'
-    },
-    input: {
-        flex: 1
-    }
-})
 
 export default VoiceTextInput

--- a/src/constants/validation.ts
+++ b/src/constants/validation.ts
@@ -1,0 +1,17 @@
+/**
+ * 店舗情報のテキスト項目の文字数上限
+ *
+ * API 側の storeValidationRules と一致させること。
+ * 255 は DB の VarChar(255) 由来、1000 は Text 型（DB 上限なし）に対して
+ * アプリ側で定めた自由記述欄の妥当値。
+ */
+export const STORE_TEXT_MAX_LENGTH = {
+    STORE_NAME: 255,
+    BRANCH_NAME: 255,
+    ADDRESS: 255,
+    BUSINESS_HOURS: 255,
+    REGULAR_HOLIDAYS: 255,
+    TOPPING_DETAILS: 1000,
+    CALL_DETAILS: 1000,
+    LOT_DETAIL: 1000
+} as const

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,30 @@
+/**
+ * express-validator が返すフィールド単位のエラー情報
+ * （API 側 handleValidationErrors が詰める details 配列の要素に対応）
+ *
+ * value は `.trim()` サニタイザ適用後の値が入るため、
+ * 送信した値とは一致しないことがある（"   " を送ると "" が返る）。
+ */
+export interface ApiErrorDetail {
+    type?: string;
+    value?: unknown;
+    msg: string;
+    path: string;
+    location?: string;
+}
+
+/**
+ * API のエラーレスポンスボディ。出所によって3形状あり、
+ * メッセージが入るキーが `error` と `message` で異なる。
+ *
+ * - バリデーションミドルウェア: `{ success, error, details[] }`
+ * - サービス層（AppError）    : `{ success, error }`
+ * - 認証ミドルウェア          : `{ status, message }`
+ */
+export interface ApiErrorResponse {
+    success?: boolean;
+    error?: string;
+    details?: ApiErrorDetail[];
+    status?: string;
+    message?: string;
+}

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -1,0 +1,15 @@
+import { Control, FieldValues, Path } from "react-hook-form"
+
+export interface FormTextInputProps<T extends FieldValues> {
+    control: Control<T>;
+    name: Path<T>;
+    label: string;
+    isRequired?: boolean;
+    /** サーバと同じ基準（コードポイント数）で判定する文字数上限 */
+    maxLength?: number;
+    multiline?: boolean;
+    numberOfLines?: number;
+    /** 音声入力ボタンを表示するか */
+    enableVoiceInput?: boolean;
+    onSpeechResult?: (value: string) => void;
+}

--- a/src/types/voice.ts
+++ b/src/types/voice.ts
@@ -1,4 +1,5 @@
-import { Control, FieldValues, Path } from "react-hook-form"
+import { FieldValues } from "react-hook-form"
+import { FormTextInputProps } from "./form"
 
 export interface VoiceInputButtonProps {
     onSpeechResult: (text: string) => void;
@@ -6,12 +7,11 @@ export interface VoiceInputButtonProps {
     size?: number;
 }
 
-export interface VoiceTextInputProps<T extends FieldValues> {
-    control: Control<T>;
-    name: Path<T>;
-    label: string;
-    isRequired?: boolean;
-    multiline?: boolean;
-    numberOfLines?: number;
-    onSpeechResult?: (text: string) => void;
-}
+/**
+ * VoiceTextInput は音声入力を有効にした FormTextInput のため、
+ * enableVoiceInput 以外のプロパティをそのまま受け取る。
+ */
+export type VoiceTextInputProps<T extends FieldValues> = Omit<
+    FormTextInputProps<T>,
+    "enableVoiceInput"
+>

--- a/src/utils/apiErrorUtils.ts
+++ b/src/utils/apiErrorUtils.ts
@@ -40,15 +40,32 @@ export const applyApiFieldErrors = <T extends FieldValues>(
         return toDisplayMessage(error, fallback)
     }
 
+    // 1項目に対して複数の details が返ることがあるため、項目ごとに集約してから
+    // まとめて設定する（項目ごとに setError すると最後の1件しか残らない）。
+    // 同じ文言が重複することもあるので取り除く。
+    //   例) store_name に "" を送ると trim 前後の notEmpty() 双方で弾かれ
+    //       「店舗名は必須です」が2件、null なら型チェックも加わり3件返る
+    const fieldMessages = new Map<Path<T>, string[]>()
     const unmappedMessages: string[] = []
 
     error.details?.forEach((detail) => {
         const path = detail.path as Path<T>
+
         if (formFieldNames.includes(path)) {
-            setError(path, { type: "server", message: detail.msg })
-        } else {
+            const messages = fieldMessages.get(path) ?? []
+            if (!messages.includes(detail.msg)) {
+                fieldMessages.set(path, [...messages, detail.msg])
+            }
+            return
+        }
+
+        if (!unmappedMessages.includes(detail.msg)) {
             unmappedMessages.push(detail.msg)
         }
+    })
+
+    fieldMessages.forEach((messages, path) => {
+        setError(path, { type: "server", message: messages.join("\n") })
     })
 
     return unmappedMessages.length > 0

--- a/src/utils/apiErrorUtils.ts
+++ b/src/utils/apiErrorUtils.ts
@@ -1,0 +1,57 @@
+import { FieldValues, Path, UseFormSetError } from "react-hook-form"
+import { ApiError } from "../api/Apiclient"
+
+/**
+ * 例外をそのまま画面に出せるメッセージへ変換する
+ *
+ * API のエラーは出所によって `details` の有無が変わるため、
+ * details があればフィールド単位のメッセージを、無ければ本文を表示する。
+ *
+ * @param error catch した例外
+ * @param fallback Error ですらない値だった場合に表示する文言
+ * @returns 画面表示用のメッセージ
+ */
+export const toDisplayMessage = (error: unknown, fallback: string): string => {
+    if (error instanceof ApiError) return error.displayMessage
+    if (error instanceof Error) return error.message
+    return fallback
+}
+
+/**
+ * API のバリデーションエラーをフォームのインラインエラーへ反映する
+ *
+ * details[].path がフォームの入力項目と一致するものはインライン表示に回し、
+ * 一致しないもの（topping_calls.0.topping_id など画面に入力欄が無い項目）は
+ * 表示されないまま握り潰されないよう、まとめて戻り値のメッセージへ含める。
+ *
+ * @param error catch した例外
+ * @param setError react-hook-form の setError
+ * @param formFieldNames フォームが持つ入力項目名
+ * @param fallback Error ですらない値だった場合に表示する文言
+ * @returns スナックバー等に表示すべきメッセージ
+ */
+export const applyApiFieldErrors = <T extends FieldValues>(
+    error: unknown,
+    setError: UseFormSetError<T>,
+    formFieldNames: readonly Path<T>[],
+    fallback: string
+): string => {
+    if (!(error instanceof ApiError) || !error.hasFieldErrors) {
+        return toDisplayMessage(error, fallback)
+    }
+
+    const unmappedMessages: string[] = []
+
+    error.details?.forEach((detail) => {
+        const path = detail.path as Path<T>
+        if (formFieldNames.includes(path)) {
+            setError(path, { type: "server", message: detail.msg })
+        } else {
+            unmappedMessages.push(detail.msg)
+        }
+    })
+
+    return unmappedMessages.length > 0
+        ? unmappedMessages.join("\n")
+        : "入力内容にエラーがあります。各項目のメッセージを確認してください。"
+}

--- a/src/utils/storeFormUtils.ts
+++ b/src/utils/storeFormUtils.ts
@@ -1,0 +1,41 @@
+import { Path } from "react-hook-form"
+import { StoreData } from "../types/store"
+
+/**
+ * 店舗フォームが入力欄を持つテキスト項目
+ *
+ * API の details[].path のうち、この一覧に含まれるものだけを
+ * インラインエラーとして表示できる。真偽値項目（Switch）は
+ * エラー表示欄を持たないため、あえて含めない。
+ */
+export const STORE_TEXT_FIELD_NAMES: readonly Path<StoreData>[] = [
+    "store_name",
+    "branch_name",
+    "address",
+    "business_hours",
+    "regular_holidays",
+    "topping_details",
+    "call_details",
+    "lot_detail"
+]
+
+/**
+ * 送信前にテキスト項目の前後の空白を除去する
+ *
+ * サーバは `.trim()` サニタイザで前後の空白を落とした値を保存する。
+ * 送信値を揃えておかないと、登録直後の画面の値と再取得した値がズレる。
+ *
+ * @param data フォームの入力値
+ * @returns テキスト項目を trim 済みにした送信用データ
+ */
+export const trimStoreTextFields = (data: StoreData): StoreData => ({
+    ...data,
+    store_name: data.store_name.trim(),
+    branch_name: data.branch_name?.trim(),
+    address: data.address.trim(),
+    business_hours: data.business_hours.trim(),
+    regular_holidays: data.regular_holidays.trim(),
+    topping_details: data.topping_details?.trim(),
+    call_details: data.call_details?.trim(),
+    lot_detail: data.lot_detail?.trim()
+})

--- a/src/utils/textUtils.ts
+++ b/src/utils/textUtils.ts
@@ -1,0 +1,24 @@
+// 異体字セレクタ（U+FE0F/U+FE0E）を伴う文字。直前の1文字とセットで1文字と数える
+const PRESENTATION_SEQUENCE = /[^\uFE0F\uFE0E][\uFE0F\uFE0E]/g
+// サロゲートペア（絵文字など BMP 外の文字）。2コード単位で1文字と数える
+const SURROGATE_PAIR = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g
+
+/**
+ * サーバと同じ数え方で文字数を返す
+ *
+ * サーバは express-validator（validator.js）の isLength で長さを判定しており、
+ * その実装は「UTF-16 のコード単位数から、異体字セレクタとサロゲートペアの
+ * 余剰分を差し引く」というもの。ここでは同じ計算を再現している。
+ *
+ * String#length をそのまま使うと絵文字を2文字と数えてサーバより厳しくなり、
+ * 実際には通る入力を弾いてしまう。逆に [...value].length（コードポイント数）は
+ * 異体字セレクタを1文字余分に数えるため、"❤️" のような文字でやはりズレる。
+ *
+ * @param value 数える文字列
+ * @returns サーバ基準の文字数
+ */
+export const countChars = (value: string): number => {
+    const presentationSequences = value.match(PRESENTATION_SEQUENCE)?.length ?? 0
+    const surrogatePairs = value.match(SURROGATE_PAIR)?.length ?? 0
+    return value.length - presentationSequences - surrogatePairs
+}


### PR DESCRIPTION
## 背景

API側で以下3点の変更が入ったことへの対応（`front修正ポイント.md`）。

1. 必須テキスト項目が `trim()` 後の空判定を行うようになり、空白のみの値が 400 になる
2. 任意項目（`branch_name` / `topping_details` / `call_details` / `lot_detail`）に文字数上限（255 / 1000）が追加された
3. 画像の Base64 形式エラーが 500 → 400 になり、理由がメッセージで返るようになった

影響調査の過程で、**それ以前にフロント側が API のエラー本文を読めておらず、書き込み系 API には認証ヘッダすら付いていない**ことが判明したため、そこから対応した。

## 変更内容

### 1. `Apiclient.ts` — 認証インターセプタ

`POST /stores` / `PUT /stores/:id` / `PATCH /stores/:id/close` / `POST /stores/:storeId/images` は API 側で `authenticateUser` が必須だが、`AuthApi.ts` 以外は `Authorization` ヘッダを付けておらず 401 になっていた。全リクエストに Firebase ID トークンを付与する。

- `getIdToken()` は有効期限内ならキャッシュを返すため、毎回の通信は発生しない
- 未ログイン時・トークン取得失敗時はヘッダを付けずに続行し、認証不要な参照系 API を巻き添えにしない

### 2. `Apiclient.ts` — エラー本文の取得（本 PR の急所）

API のエラーレスポンスは出所によってメッセージのキーが異なる。

| 出所 | ボディ | `data.message` |
|---|---|---|
| バリデーションミドルウェア | `{ success, error, details[] }` | ❌ |
| サービス層（AppError） | `{ success, error }` | ❌ |
| 認証ミドルウェア | `{ status, message }` | ✅ |

従来実装は `data.message` だけを見ていたため、**400 は例外なく `axiosError.message` にフォールバックし「Request failed with status code 400」と表示されていた**。上記②③でサーバのメッセージが親切になっても、フロント側で捨てていた状態。

`error` / `message` の両方を見て取り出し、ステータスコードと `details` を保持する `ApiError` に詰め替える。素の `Error` では「400 はリトライ対象外」「`details[].path` でインライン表示」といった判断ができないため。

### 3. `FormTextInput` 新設（①②対応）

`create.tsx` / `update.tsx` にほぼ同一のフォーム定義が重複していたため集約。

- **必須項目は空白のみ（`"   "`）も弾く。** react-hook-form の `required` は `"   "` を truthy な文字列として通してしまい、サーバの `trim()` 後 `notEmpty()` で 400 になっていた
- **文字数カウンタとバリデーション**（255 / 1000）を追加。従来は `maxLength` の設定が一切なかった
- 送信前にテキスト項目を `trim()` し、サーバの保存値と画面の値を揃える

`VoiceTextInput` は音声入力を有効にした薄いラッパーとして維持（呼び出し側の API は不変）。

#### 文字数カウントについて

サーバは `validator.js` の `isLength` を使っており、`String#length` では絵文字を2文字と数えてサーバより厳しくなる。一方 `[...value].length`（コードポイント数）も**異体字セレクタでズレる**（`"❤️"` × 255 はサーバは通すが弾いてしまう）。

そのため `isLength` と同一アルゴリズムを `countChars` として移植し、実測で一致を確認した。

```
"あ" x255      server=true  client=true  一致
"😀" x255     server=true  client=true  一致
"❤️" x255     server=true  client=true  一致   ← [...v].length では不一致
"☺️" x255     server=true  client=true  一致
"👨‍👩‍👦" x50  server=true  client=true  一致
"a"  x1001    server=false client=false 一致
```

RN の `maxLength` は UTF-16 コード単位で数えるため、上限をそのまま渡すと絵文字がサーバより早く切られる。暴走ペースト対策として上限の4倍を設定し、厳密な判定は `validate` に任せている（サーバ基準の1文字は最大3コード単位）。

### 4. 400 の表示（③対応）

`details[]` を各入力欄のインラインエラーへ反映し、入力欄を持たない項目（`topping_calls.*` など）の分はスナックバーへ出して握り潰されないようにする。`details` が無い形状（AppError 由来）は本文をそのまま表示するフォールバックを用意。

### 5. `image_upload.tsx` — data URL の MIME（③対応・既存バグ）

data URL のプレフィックスを**元画像の `mimeType`** から組み立てていたが、`getFormatFromMimeType` は未対応形式を JPEG へフォールバックするため、実データと宣言がズレていた。

| 元 MIME | 実データ | 修正前 | 修正後 |
|---|---|---|---|
| `image/heic`（iPhone） | JPEG | **400** | OK |
| `image/bmp` | JPEG | **400** | OK |
| `undefined` | JPEG | **400** | OK |
| `image/gif` | JPEG | 通過するが中身と不一致 | OK（`image/jpeg` として宣言） |

プレフィックスを実際の保存形式から引くよう修正。あわせて、成否と文言が別々に更新されスナックバーが空になることがあった表示を統一した。

## 対応不要と判断した項目

`front修正ポイント.md` の「リトライ／監視の扱い」は、本アプリに `axios-retry`・リトライインターセプタ・Sentry のいずれも導入されていないため該当なし。

## 検証

- `npm run typecheck` — pass
- `npx eslint src` — pass
- `countChars` と API の `validator.isLength` の一致を実測（上表）
- 組み立てた data URL が API の正規表現を通ることを実測（上表）

**実機での動作確認は未実施です。**

## 別途対応が必要（本 PR 対象外）

- `AuthApi.ts` の `createUser` / `getUserByUid` が `ApiClient.handleError(...)` の戻り値を `throw` しておらず、API 側の失敗が握り潰されている（サインアップは Firebase 認証だけ成功して DB 未登録のまま `store/map` へ遷移しうる）。挙動が変わるため本 PR には含めていません
- 同ファイルの手動 `Authorization` ヘッダはインターセプタと重複（同一トークンの上書きのため無害）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 店舗情報フォームに文字数上限、文字数表示、必須入力チェックを追加しました。
  * 音声入力に対応した共通テキスト入力を提供します。
  * APIエラーを画面表示や入力項目ごとのエラーとして分かりやすく表示します。
  * 画像アップロード時の形式に応じた処理を改善しました。

* **改善**
  * 店舗情報送信時に前後の空白を自動的に除去します。
  * 店舗作成・編集画面の入力体験とエラー表示を統一しました。
  * 認証情報を利用したAPI通信の安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->